### PR TITLE
Gsap FromTo fundamentals

### DIFF
--- a/src/pages/GsapFromTo.jsx
+++ b/src/pages/GsapFromTo.jsx
@@ -1,5 +1,23 @@
+import { useGSAP } from "@gsap/react";
+import gsap from "gsap";
+
 const GsapFromTo = () => {
   // TODO: Implement the gsap.fromTo() method
+  useGSAP(() => {
+    gsap.fromTo('#red-box', {
+      x: 0,
+      rotation: 0,
+      borderRadius: '0%',
+    },{
+      x: 250,
+      repeat: -1,
+      yoyo: true,
+      borderRadius: '100%',
+      rotation: 360,
+      duration: 2,
+      ease: 'bounce.out'
+    })
+  }, []);
 
   return (
     <main>


### PR DESCRIPTION
**GsapFromTo**
The gsap.fromTo() method is used to animate elements from a new state to a new state.

The gsap.fromTo() method is similar to the gsap.from() and gsap.to() methods, but the difference is that the gsap.fromTo() method animates elements from a new state to a new state, while the gsap.from() method animates elements from a new state to their current state, and the gsap.to() method animates elements from their current state to a new state.

Read more about the [gsap.fromTo()](https://greensock.com/docs/v3/GSAP/gsap.fromTo()) method.